### PR TITLE
Fix: Handle missing or invalid Snyk token

### DIFF
--- a/utils/helper.py
+++ b/utils/helper.py
@@ -6,7 +6,7 @@ def get_snyk_token():
     SNYK_TOKEN = check_if_snyk_token_exist()
     
     pattern = re.compile(r'([\d\w]{8}-[\d\w]{4}-[\d\w]{4}-[\d\w]{4}-[\d\w]{12})')
-    if pattern.fullmatch(SNYK_TOKEN) == None:
+    if SNYK_TOKEN is None or pattern.fullmatch(SNYK_TOKEN) is None:
         print("Snyk token is not defined or not valid.")
         sys.exit()
     else:
@@ -20,4 +20,4 @@ def check_if_snyk_token_exist():
             return os.getenv('SNYK_TOKEN')
     except:
         print("Snyk token does not exist")
-        sys.exit()
+        return None


### PR DESCRIPTION
This commit improves the way the application handles situations where the Snyk API token is either missing from the environment or is not in the correct format. Instead of immediately crashing, the application will now check for the presence and validity of the token. If the token is missing or invalid, a message will be displayed, and the application will exit gracefully. This provides a better user experience by preventing unexpected crashes and giving users clear guidance on how to resolve the issue.